### PR TITLE
fix: remove `apis_core.generic` from settings

### DIFF
--- a/discworld/settings.py
+++ b/discworld/settings.py
@@ -28,5 +28,3 @@ LANGUAGE_CODE = 'en-us'
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
-
-INSTALLED_APPS += ["apis_core.generic"]


### PR DESCRIPTION
it is now part of the default settings
